### PR TITLE
tiny changes to changelog

### DIFF
--- a/prbt_default_application/CHANGELOG.rst
+++ b/prbt_default_application/CHANGELOG.rst
@@ -8,8 +8,8 @@ version using ``dpkg -l | grep "prbt-\|pilz-"``.
 
 Forthcoming
 -----------
-* revision of launchfile
-* rename of sto to run_permitted
+* update launchfile to new version in prbt_support: rename ``sto`` to ``safety_hw`` and ``sto_modbus_server_ip`` to ``modbus_server_ip``
+* add options to disable operation mode and braketest features
 
 2020-02-17
 ----------


### PR DESCRIPTION
Follow-up for #16, thanks to @ct2034 for the refactoring!
This PR refines the changelog with more verbose information how to migrate an existing launch-file created from a previous version. The former option `sto`:=`pnoz` now translates to `safety_hw`:=`pnoz`.