### PR TITLE
Add launch arg enable_safety_interface

### DIFF
--- a/prbt_default_application/CHANGELOG.rst
+++ b/prbt_default_application/CHANGELOG.rst
@@ -8,8 +8,10 @@ version using ``dpkg -l | grep "prbt-\|pilz-"``.
 
 Forthcoming
 -----------
+* add launchfile argument ``iso10218_support``
 * update launchfile to new version in prbt_support: rename ``sto`` to ``safety_hw`` and ``sto_modbus_server_ip`` to ``modbus_server_ip``
 * add options to disable operation mode and braketest features
+* Contributors: Pilz GmbH and Co. KG
 
 2020-02-17
 ----------

--- a/prbt_default_application/launch/my_application.launch
+++ b/prbt_default_application/launch/my_application.launch
@@ -69,6 +69,9 @@ limitations under the License.
       <!-- <arg name="has_operation_mode_support" default="false"/> -->
       <!-- <arg name="visual_status_indicator" default="false"/> -->
 
+      <!-- For debugging purposes you can start without the Modbus connection. Keep in mind that this disables all safety features! -->
+      <!-- <arg name="enable_safety_interface" value="false"/> -->
+
       <!-- Set the name of the config file for canopen_motor_node. If you want to change settings, copy the yaml
            file into your package and set canopen_config to your new config file path.
            See http://wiki.ros.org/canopen_chain_node for available configuration options. -->

--- a/prbt_default_application/launch/my_application.launch
+++ b/prbt_default_application/launch/my_application.launch
@@ -70,7 +70,7 @@ limitations under the License.
       <!-- <arg name="visual_status_indicator" default="false"/> -->
 
       <!-- For debugging purposes you can start without the Modbus connection. Keep in mind that this disables all safety features! -->
-      <!-- <arg name="enable_safety_interface" value="false"/> -->
+      <!-- <arg name="iso10218_support" value="false"/> -->
 
       <!-- Set the name of the config file for canopen_motor_node. If you want to change settings, copy the yaml
            file into your package and set canopen_config to your new config file path.
@@ -123,4 +123,3 @@ limitations under the License.
   <!-- <node name="my_application" pkg="prbt_default_application" type="myApplication.py" /> -->
 
 </launch>
-


### PR DESCRIPTION
This explains how to start ROS without the Modbus connection. Depends on https://github.com/PilzDE/pilz_robots/pull/353.